### PR TITLE
Make sure Proxies are always initialised with a valid object

### DIFF
--- a/.changeset/curly-dryers-tell.md
+++ b/.changeset/curly-dryers-tell.md
@@ -1,0 +1,5 @@
+---
+"@stevent-team/react-zoom-form": patch
+---
+
+Always init Proxy with object

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -55,7 +55,7 @@ export type PathSegment = {
  * Thanks to [react-zorm](https://github.com/esamattis/react-zorm) for the inspiration.
  */
 export const fieldChain = <S extends z.ZodType>(schema: S, path: PathSegment[], register: RegisterFn, controls: Omit<FieldControls<z.ZodTypeAny>, 'schema' | 'path'>): any =>
-  new Proxy(() => void {}, {
+  new Proxy({}, {
     get: (_target, key) => {
       if (typeof key !== 'string') {
         throw new Error(`${String(key)} must be a string`)
@@ -87,7 +87,7 @@ export const fieldChain = <S extends z.ZodType>(schema: S, path: PathSegment[], 
   }) as unknown
 
 export const errorChain = <S extends z.ZodType>(schema: S, path: PathSegment[], error?: z.ZodError<z.infer<S>>): any =>
-  new Proxy(() => void {}, {
+  new Proxy({}, {
     get: (_target, key) => {
       if (typeof key !== 'string') {
         throw new Error(`${String(key)} must be a string`)

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -55,7 +55,7 @@ export type PathSegment = {
  * Thanks to [react-zorm](https://github.com/esamattis/react-zorm) for the inspiration.
  */
 export const fieldChain = <S extends z.ZodType>(schema: S, path: PathSegment[], register: RegisterFn, controls: Omit<FieldControls<z.ZodTypeAny>, 'schema' | 'path'>): any =>
-  new Proxy(schema, {
+  new Proxy(() => void {}, {
     get: (_target, key) => {
       if (typeof key !== 'string') {
         throw new Error(`${String(key)} must be a string`)
@@ -87,7 +87,7 @@ export const fieldChain = <S extends z.ZodType>(schema: S, path: PathSegment[], 
   }) as unknown
 
 export const errorChain = <S extends z.ZodType>(schema: S, path: PathSegment[], error?: z.ZodError<z.infer<S>>): any =>
-  new Proxy(schema, {
+  new Proxy(() => void {}, {
     get: (_target, key) => {
       if (typeof key !== 'string') {
         throw new Error(`${String(key)} must be a string`)


### PR DESCRIPTION
Fixes an issue where sometimes an error would occur if a Proxy was created with `undefined` as it's initial value