### PR TITLE
Don't apply Partial to custom field if type is an array

### DIFF
--- a/.changeset/chilled-camels-shake.md
+++ b/.changeset/chilled-camels-shake.md
@@ -1,0 +1,5 @@
+---
+"@stevent-team/react-zoom-form": patch
+---
+
+Don't apply Partial to custom field if type is an array


### PR DESCRIPTION
Previously, if a custom field used an array type, Partial would be applied and a type of `string[]` would be transformed to `(string | undefined)[]`. This is not desired behaviour as a scenario where an individual array element is undefined cannot happen in the context of a field.

A type helper `PartialObject` will not apply `Partial` if the type is an array.