### PR TITLE
Rename `errors` fn

### DIFF
--- a/.changeset/spicy-carpets-pump.md
+++ b/.changeset/spicy-carpets-pump.md
@@ -1,0 +1,5 @@
+---
+"@stevent-team/react-zoom-form": minor
+---
+
+Changed name of `errors` fn to `fieldErrors` to be clearer about it's function

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ yarn add @stevent-team/react-zoom-form zod
 ### Basic Example
 
 ```tsx
-import { useForm, errors } from '@stevent-team/react-zoom-form'
+import { useForm, fieldErrors } from '@stevent-team/react-zoom-form'
 import { z } from 'zod'
 
 // Define the structure and validation of your form
@@ -45,7 +45,7 @@ const EditPage = () => {
     <input {...fields.address.street.register()} type="text" />
     <input {...fields.address.city.register()} type="text" />
     <button>Save changes</button>
-    {errors(fields).length > 0 && <div>{errors(fields).map(err => err.message).join(', ')}</div>}
+    {fieldErrors(fields).length > 0 && <div>{fieldErrors(fields).map(err => err.message).join(', ')}</div>}
   </form>
 }
 ```
@@ -53,7 +53,7 @@ const EditPage = () => {
 ### Error Handling
 
 ```tsx
-import { useForm, errors } from '@stevent-team/react-zoom-form'
+import { useForm, fieldErrors } from '@stevent-team/react-zoom-form'
 import { z } from 'zod'
 
 // Define the structure and validation of your form
@@ -64,7 +64,7 @@ const schema = z.object({
 
 // Display comma separated error messages
 const Error = ({ field }: { field: { _field: FieldControls } }) => {
-  const fieldErrors = errors(field) // Extract errors for this field
+  const fieldErrors = fieldErrors(field) // Extract errors for this field
   return fieldErrors.length > 0 ? <span className="error">{fieldErrors.map(e => e.message).join(', ')}</span> : null
 }
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,4 +1,4 @@
-import { SubmitHandler, useForm, Field, controlled, errors, FieldControls } from '@stevent-team/react-zoom-form'
+import { SubmitHandler, useForm, Field, controlled, fieldErrors, FieldControls } from '@stevent-team/react-zoom-form'
 import { z } from 'zod'
 
 // Define the structure and validation of your form
@@ -27,8 +27,8 @@ const schema = z.object({
 })
 
 const Error = ({ field }: { field: { _field: FieldControls } }) => {
-  const fieldErrors = errors(field)
-  return fieldErrors.length > 0 ? <span className="error">{fieldErrors.map(e => `${e.message} (${e.code})`).join(', ')}</span> : null
+  const errors = fieldErrors(field)
+  return errors.length > 0 ? <span className="error">{errors.map(e => `${e.message} (${e.code})`).join(', ')}</span> : null
 }
 
 const initialValues = {
@@ -103,7 +103,7 @@ const App = () => {
     <output>
       <div>isDirty: {isDirty ? 'true' : 'false'}</div>
       <div>value: {JSON.stringify(value, null, 2)}</div>
-      <div>errors: {JSON.stringify(errors(fields), null, 2)}</div>
+      <div>errors: {JSON.stringify(fieldErrors(fields), null, 2)}</div>
     </output>
   </form>
 }

--- a/lib/field.ts
+++ b/lib/field.ts
@@ -98,8 +98,8 @@ export const controlled = <T>({ _field }: { _field: FieldControls<z.ZodType<NonN
  * @example
  * ```tsx
  * <input type="text" {...fields.myInput.register()} />
- * <span>{errors(fields.myInput).map(e => e.message).join(', ')}</span>
+ * <span>{fieldErrors(fields.myInput).map(e => e.message).join(', ')}</span>
  * ```
  */
-export const errors = <T>({ _field: { formErrors, path } }: { _field: FieldControls<z.ZodType<T>> }): z.ZodIssue[] =>
+export const fieldErrors = <T>({ _field: { formErrors, path } }: { _field: FieldControls<z.ZodType<T>> }): z.ZodIssue[] =>
   formErrors?.issues?.filter(issue => arrayStartsWith(issue.path, path.map(p => p.key))) ?? []

--- a/test/basic.test.tsx
+++ b/test/basic.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { z } from 'zod'
-import { FieldControls, SubmitHandler, errors, useForm } from '@stevent-team/react-zoom-form'
+import { FieldControls, SubmitHandler, fieldErrors, useForm } from '@stevent-team/react-zoom-form'
 import userEvent from '@testing-library/user-event'
 
 const schema = z.object({
@@ -10,7 +10,7 @@ const schema = z.object({
 })
 
 const FormError = ({ field }: { field: { _field: FieldControls } }) =>
-  errors(field).length > 0 ? <span className="error" role="alert">{errors(field).map(e => `${e.message} (${e.code})`).join(', ')}</span> : null
+  fieldErrors(field).length > 0 ? <span className="error" role="alert">{fieldErrors(field).map(e => `${e.message} (${e.code})`).join(', ')}</span> : null
 
 const BasicForm = ({ onSubmit }: { onSubmit: SubmitHandler<typeof schema> }) => {
   const { fields, handleSubmit } = useForm({ schema })


### PR DESCRIPTION
`fieldErrors` is clearer and has less of a chance to conflict with existing variables