### PR TITLE
Support nullable and optional zod schemas in the fields object type

### DIFF
--- a/.changeset/proud-balloons-check.md
+++ b/.changeset/proud-balloons-check.md
@@ -1,0 +1,5 @@
+---
+"@stevent-team/react-zoom-form": patch
+---
+
+Support nullable and optional zod schemas in the fields object type

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -4,14 +4,14 @@ import { z } from 'zod'
 // Define the structure and validation of your form
 const schema = z.object({
   requiredString: z.string().trim().min(1, 'This field is required').default(''),
-  optionalString: z.string().trim().default(''),
+  optionalString: z.string().trim().nullish(),
   defaultString: z.string().trim().default('Default value'),
   number: z.coerce.number().min(3).max(10),
   nested: z.object({
     inside: z.object({
       here: z.string().trim().min(1),
     }),
-  }),
+  }).optional(),
   array: z.array(
     z.object({
       prop: z.string().trim().min(1),

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -2,17 +2,14 @@ import { FieldControls, FieldRefs, RegisterFn } from '.'
 import { z } from 'zod'
 
 // Creates the type for the field chain
-type recursiveFormatSchemaFields<Schema extends z.ZodType, Value> = z.infer<Schema> extends Value ? z.infer<Schema>
-  : Schema extends z.AnyZodTuple ? {
-    [K in keyof z.infer<Schema>]: FormatSchemaFields<Schema['_type'][K], Value>
-  } : Schema extends z.ZodArray<any> ? {
-    [k: number]: FormatSchemaFields<Schema['_def']['type'], Value>
-  } : Schema extends z.AnyZodObject ? {
-    [K in keyof z.infer<Schema>]: FormatSchemaFields<Schema['shape'][K], Value>
-  } : Schema extends z.ZodDefault<any> ?
-    FormatSchemaFields<Schema['_def']['innerType'], Value>
+type recursiveFormatSchemaFields<Schema extends z.ZodType, Value> =
+  z.infer<Schema> extends Value ? z.infer<Schema>
+  : Schema extends z.AnyZodTuple ? { [K in keyof z.infer<Schema>]: FormatSchemaFields<Schema['_type'][K], Value> }
+  : Schema extends z.ZodArray<any> ? { [k: number]: FormatSchemaFields<Schema['_def']['type'], Value> }
+  : Schema extends z.AnyZodObject ? { [K in keyof z.infer<Schema>]: FormatSchemaFields<Schema['shape'][K], Value> }
+  : Schema extends (z.ZodDefault<any> | z.ZodOptional<any> | z.ZodNullable<any>) ? FormatSchemaFields<Schema['_def']['innerType'], Value>
   : Value
-export type FormatSchemaFields<Schema extends z.ZodType, Value> = { _field: FieldControls<Schema> } & recursiveFormatSchemaFields<NonNullable<Schema>, Value>
+export type FormatSchemaFields<Schema extends z.ZodType, Value> = { _field: FieldControls<Schema> } & Required<recursiveFormatSchemaFields<NonNullable<Schema>, Value>>
 
 /** Recursively make a nested object structure partial */
 export type RecursivePartial<T> = {


### PR DESCRIPTION
Fixes a bug where zod schemas with `nullable` or `optional` flags would break the `fields` object's types