### PR TITLE
Fix validation on change running after a reset

### DIFF
--- a/.changeset/fast-dogs-wait.md
+++ b/.changeset/fast-dogs-wait.md
@@ -1,0 +1,5 @@
+---
+"@stevent-team/react-zoom-form": patch
+---
+
+Disable validation on change after a reset until the next submit event

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# React Zoom Form <img width="400" align="right" src="https://github.com/stevent-team/react-zoom-form/assets/16392483/e7898088-ccfc-4899-9f35-a32faaf8964c" alt="car">
+# React Zoom Form <img width="300" align="right" src="https://github.com/stevent-team/react-zoom-form/assets/16392483/e7898088-ccfc-4899-9f35-a32faaf8964c" alt="car">
 
 [![npm version](https://img.shields.io/npm/v/@stevent-team/react-zoom-form)](https://www.npmjs.com/package/@stevent-team/react-zoom-form)
 [![minzip size](https://img.shields.io/bundlephobia/minzip/@stevent-team/react-zoom-form)](https://bundlephobia.com/package/@stevent-team/react-zoom-form)

--- a/lib/useForm.ts
+++ b/lib/useForm.ts
@@ -57,6 +57,7 @@ export const useForm = <Schema extends z.AnyZodObject>({
   const isDirty = useMemo(() => !deepEqual(formValue, internalInitialValues), [formValue, internalInitialValues])
 
   const reset = useCallback<UseFormReturn<Schema>['reset']>((values = initialValues) => {
+    setValidateOnChange(false)
     setInternalInitialValues(values)
     setFormValue(values)
   }, [initialValues])


### PR DESCRIPTION
Just disables `validateOnChange` after calling `reset` until the next submit