### PR TITLE
Custom ref support for registered fields

### DIFF
--- a/.changeset/cuddly-tomatoes-glow.md
+++ b/.changeset/cuddly-tomatoes-glow.md
@@ -1,0 +1,5 @@
+---
+"@stevent-team/react-zoom-form": minor
+---
+
+Support passing a custom ref into registered elements

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ If you also need access to the `ref` of an input you're using `register()` on, y
 ```tsx
 const { fields } = useForm({ schema })
 
-const myInputRef = useRef<HTMLInputElement>()
+const myInputRef = useRef<HTMLInputElement>(null)
 
 return <form>
   <input {...fields.myInput.register({ ref: myInputRef })} />

--- a/README.md
+++ b/README.md
@@ -360,6 +360,25 @@ return <form>
 </form>
 ```
 
+### Custom Reference
+
+If you also need access to the `ref` of an input you're using `register()` on, you can pass it to the options of register like so:
+
+```tsx
+const { fields } = useForm({ schema })
+
+const myInputRef = useRef<HTMLInputElement>()
+
+return <form>
+  <input {...fields.myInput.register({ ref: myInputRef })} />
+
+  <button
+    type="button"
+    onClick={() => myInputRef.current.focus()}
+  >Focus my input</button>
+</form>
+```
+
 ### Tips
 
 - If you're computing your schema inside the react component that calls `useForm`, be sure to memoize the schema so rerenders of the component do not recalculate the schema. This also goes for `initialValues`.
@@ -392,7 +411,7 @@ The `fields` object will match the shape of your Zod schema, and also provides a
 
 | Property | Type | Description |
 | --- | --- | --- |
-| `register` | `() => ReturnType<RegisterFn>` | Returns `onChange`, `name` and `ref` props that you can pass to a native `input`, `textarea` or `select` element. |
+| `register` | `(options?: RegisterOptions) => ReturnType<RegisterFn>` | Takes options and returns `onChange`, `name` and `ref` props that you can pass to a native `input`, `textarea` or `select` element. |
 | `name` | `() => string` | Returns a unique name for this field. Useful for linking `label` elements. |
 
 ### `controlled`

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,4 +1,4 @@
-import { Field, FieldRefs, RegisterFn } from '.'
+import { Field, FieldRefs, RegisterFn, RegisterOptions } from '.'
 import { z } from 'zod'
 
 // Creates the type for the field chain by recusively travelling through the Zod schema
@@ -17,7 +17,7 @@ export type FieldChain<Schema extends z.ZodType> = Field<Schema> & Required<recu
    * @example
    * <input type="text" {...fields.firstName.register()} />
    */
-  register: () => ReturnType<RegisterFn>
+  register: (options?: RegisterOptions) => ReturnType<RegisterFn>
   /**
    * Get the name of this field used by the register function.
    *
@@ -102,7 +102,7 @@ export const fieldChain = <S extends z.ZodType>(
       // If the current Zod schema is not an array or object, we must be at a leaf node
       if (!(unwrapped instanceof z.ZodObject)) {
         // Leaf node functions
-        if (key === 'register') return () => register(path, schema, controls.setFormValue, fieldRefs)
+        if (key === 'register') return (options: RegisterOptions = {}) => register(path, schema, controls.setFormValue, fieldRefs, options)
         if (key === 'name') return () => path.map(p => p.key).join('.')
 
         // Attempted to access a property that didn't exist
@@ -110,7 +110,7 @@ export const fieldChain = <S extends z.ZodType>(
       }
 
       return fieldChain(unwrapped.shape[key], [...path, { key, type: 'object' }], register, fieldRefs, controls)
-    },
+    }
   }) as unknown // Never let them know your next move...
 
 type Obj = Record<string, unknown> | unknown[]


### PR DESCRIPTION
Adds support for passing a custom ref to an input using `register`

```tsx
const { fields } = useForm({ schema })

const myInputRef = useRef<HTMLInputElement>(null)

return <form>
  <input {...fields.myInput.register({ ref: myInputRef })} />

  <button
    type="button"
    onClick={() => myInputRef.current.focus()}
  >Focus my input</button>
</form>
```