### PR TITLE
Remove unnecessary NonNullable on field chain

### DIFF
--- a/.changeset/olive-peaches-heal.md
+++ b/.changeset/olive-peaches-heal.md
@@ -1,0 +1,5 @@
+---
+"@stevent-team/react-zoom-form": patch
+---
+
+Remove unnecessary NonNullable on field chain

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -10,7 +10,7 @@ type recursiveFieldChain<Schema extends z.ZodType, LeafValue> =
   : Schema extends (z.ZodDefault<any> | z.ZodOptional<any> | z.ZodNullable<any>) ? FieldChain<Schema['_def']['innerType']>
   : LeafValue
 
-export type FieldChain<Schema extends z.ZodType> = Field<Schema> & Required<recursiveFieldChain<NonNullable<Schema>, {
+export type FieldChain<Schema extends z.ZodType> = Field<Schema> & Required<recursiveFieldChain<Schema, {
   /**
    * Provides props to pass to native elements (input, textarea, select)
    *


### PR DESCRIPTION
I think I added it for a reason, but it does't seem to be important anymore and was causing issues where a schema could actually be nullable.