### PR TITLE
Fix nested zod types in the field chain

### DIFF
--- a/.changeset/lovely-clouds-joke.md
+++ b/.changeset/lovely-clouds-joke.md
@@ -1,0 +1,5 @@
+---
+"@stevent-team/react-zoom-form": patch
+---
+
+Remove lib export of internal register function

--- a/.changeset/popular-pianos-wash.md
+++ b/.changeset/popular-pianos-wash.md
@@ -1,0 +1,5 @@
+---
+"@stevent-team/react-zoom-form": patch
+---
+
+Properly pass through the correct Zod schema types to the field chain using a second InnerSchema type param

--- a/examples/kitchen-sink/index.tsx
+++ b/examples/kitchen-sink/index.tsx
@@ -32,13 +32,8 @@ const initialValues = {
   defaultString: 'Default value',
 }
 
-const KitchenSink = () => {
-  const { fields, handleSubmit, isDirty, reset } = useForm({ schema, initialValues })
-
-  const onSubmit: SubmitHandler<typeof schema> = values => {
-    console.log(values)
-    reset(values)
-  }
+const KitchenSink = ({ onSubmit }: { onSubmit: SubmitHandler<typeof schema> }) => {
+  const { fields, handleSubmit, isDirty } = useForm({ schema, initialValues })
 
   return <>
     <form onSubmit={handleSubmit(onSubmit)}>


### PR DESCRIPTION
Fixes an issue with the FieldChain type that happened when an object (or any zod container) schema was used for a controlled field, and any modifiers like ZodNullable or ZodDefault were being stripped from that schema too early, resulting in them being missing from the final types.

I've also added support for more Zod types, like Map and Set. Finally I moved the `register` function back into `useForm.ts` so it doesn't have to be exported, which removes it from the library exports as it's an internal method only.