### PR TITLE
Reexport the FieldChain type

### DIFF
--- a/.changeset/twenty-hairs-explain.md
+++ b/.changeset/twenty-hairs-explain.md
@@ -1,0 +1,5 @@
+---
+"@stevent-team/react-zoom-form": patch
+---
+
+Export FieldChain helper type from the lib

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
 export * from './useForm'
 export * from './field'
 export * from './Errors'
+export type { FieldChain } from './utils'

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -16,6 +16,10 @@ type RecursiveFieldChain<Schema extends z.ZodType, LeafValue> =
   : Schema extends z.ZodPipeline<AnyZodContainer, AnyZodContainer> ? FieldChain<Schema, Schema['_def']['out']>
   : LeafValue
 
+/**
+ * Provides the type of the `fields` object from the `useForm` hook.
+ * You can use this if you intend to pass `fields` down through components to build a nested form.
+ */
 export type FieldChain<Schema extends z.ZodType, InnerSchema extends z.ZodType = Schema> = Field<Schema> & Required<RecursiveFieldChain<InnerSchema, {
   /**
    * Provides props to pass to native elements (input, textarea, select)


### PR DESCRIPTION
Useful if you need to pass the `fields` param down through component props to create a nested form etc.