### PR TITLE
Support for intersections and unions in the schema

### DIFF
--- a/.changeset/perfect-peaches-design.md
+++ b/.changeset/perfect-peaches-design.md
@@ -1,0 +1,5 @@
+---
+"@stevent-team/react-zoom-form": minor
+---
+
+Support for intersections and unions in the Zod schema

--- a/examples/App.tsx
+++ b/examples/App.tsx
@@ -8,6 +8,7 @@ import Nested from './nested'
 import Coerced from './coerced'
 import Conditional from './conditional'
 import Controlled from './controlled'
+import Intersection from './intersection'
 import KitchenSink from './kitchen-sink'
 
 interface Example {
@@ -46,6 +47,11 @@ const EXAMPLES: Example[] = [
     name: '3rd Party & Controlled Fields',
     path: '/controlled',
     component: Controlled,
+  },
+  {
+    name: 'Intersection Schema',
+    path: '/intersection',
+    component: Intersection,
   },
   {
     name: 'Kitchen Sink',

--- a/examples/intersection/index.tsx
+++ b/examples/intersection/index.tsx
@@ -1,0 +1,54 @@
+import { Errors, SubmitHandler, getValue, useForm } from '@stevent-team/react-zoom-form'
+import { z } from 'zod'
+import Output from '../Output'
+
+export const schema = z.intersection(
+  z.object({
+    common: z.string(),
+  }),
+  z.discriminatedUnion('size', [
+    z.object({
+      size: z.literal('small'),
+      smallProperty: z.string(),
+    }),
+    z.object({
+      size: z.literal('large'),
+      largeProperty: z.string(),
+    }),
+  ]),
+)
+
+const Intersection = ({ onSubmit }: { onSubmit: SubmitHandler<typeof schema> }) => {
+  const { fields, handleSubmit, isDirty } = useForm({ schema, initialValues: { size: 'small' } })
+
+  return <>
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <label htmlFor={fields.common.name()}>Common field</label>
+      <input {...fields.common.register()} id={fields.common.name()} type="text" />
+      <Errors field={fields.common} className="error" />
+
+      <label htmlFor={fields.size.name()}>Size</label>
+      <select {...fields.size.register()} id={fields.size.name()}>
+        <option value="small">Small</option>
+        <option value="large">Large</option>
+      </select>
+      <Errors field={fields.size} className="error" />
+
+      {getValue(fields.size) === 'small' ? <>
+        <label htmlFor={fields.smallProperty.name()}>Small property</label>
+        <input {...fields.smallProperty.register()} id={fields.smallProperty.name()} type="text" />
+        <Errors field={fields.smallProperty} className="error" />
+      </> : <>
+        <label htmlFor={fields.largeProperty.name()}>Large property</label>
+        <input {...fields.largeProperty.register()} id={fields.largeProperty.name()} type="text" />
+        <Errors field={fields.largeProperty} className="error" />
+      </>}
+
+      <button>Save changes</button>
+    </form>
+
+    <Output isDirty={isDirty} fields={fields} />
+  </>
+}
+
+export default Intersection


### PR DESCRIPTION
Adds support for `ZodIntersection`, `ZodUnion` and `ZodDiscriminatedUnion` in the form's Zod validation schema. Useful for conditional fields. Also added a new example to demonstrate how it can be used.