### PR TITLE
`setErrors` function

### DIFF
--- a/.changeset/great-pants-peel.md
+++ b/.changeset/great-pants-peel.md
@@ -1,0 +1,5 @@
+---
+"@stevent-team/react-zoom-form": minor
+---
+
+Add `setError` function to manually set or clear form errors

--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ You can customize the error messages in several ways.
     ```
 </details>
 
+#### Manually Set and Clear Errors
+
+Use the `setError` function to set or clear errors for a particular field, or the entire form.
+
+```tsx
+setError(fields.image, { code: 'custom', message: 'Server failed to upload' })
+
+// Clear all errors
+setError(fields, undefined)
+```
+
 ### Coercion and Validation
 
 Importantly, native HTML `input`, `textarea` and `select` all use strings to store their values. Because of this, `undefined` or `null` are not valid values for native fields, and the following schema defines a string that is _not_ required*.

--- a/lib/useForm.ts
+++ b/lib/useForm.ts
@@ -116,7 +116,7 @@ export const useForm = <Schema extends z.ZodTypeAny>({
   }, [validate])
 
   const fields = useMemo(() => new Proxy({}, {
-    get: (_target, key) => fieldChain(schema, [], register, fieldRefs, { formValue, setFormValue, formErrors })[key]
+    get: (_target, key) => fieldChain(schema, [], register, fieldRefs, { formValue, setFormValue, formErrors, setFormErrors })[key]
   }) as unknown as FieldChain<Schema>, [schema, setFormValue, formErrors])
 
   return {


### PR DESCRIPTION
Adds the ability to manually set or clear errors from a field or the entire form.

```tsx
setError(fields.image, { code: 'custom', message: 'Server failed to upload' })

// Clear all errors
setError(fields, undefined)
```